### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You first need to install [poetry](https://python-poetry.org/docs/) and enable t
   poetry config virtualenvs.in-project true
 ```
 
-Then, from within the repo you can create a new virtual environmnet with:
+Then, from within the repo you can create a new virtual environment with:
 
 ```bash 
   poetry install

--- a/app/index.py
+++ b/app/index.py
@@ -72,7 +72,7 @@ def get_features_in_bbox(conn, bbox: List[float]) -> Tuple[str]:
     query = f"""
                 SELECT co.object_id
                 FROM cjdb.city_object co
-                WHERE st_within(co.ground_geometry,
+                WHERE st_intersects(co.ground_geometry,
                 ST_MakeEnvelope({bbox[0]},
                                 {bbox[1]},
                                 {bbox[2]},


### PR DESCRIPTION
Changing the bbox function to return the geometries that intersect with the given bbox rather than the ones within, as recommended by the OGC API docs:
<img width="777" alt="image" src="https://github.com/user-attachments/assets/2a623688-a4ad-4b2e-8dd4-c6eff0db9f2f">

Before:
<img width="214" alt="image" src="https://github.com/user-attachments/assets/eece19ad-2342-4795-84df-92569008d558">

After:
<img width="286" alt="image" src="https://github.com/user-attachments/assets/64e09d74-e12e-40e0-a3ca-bd92dfb20a4a">

